### PR TITLE
fix memory issues

### DIFF
--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -875,6 +875,7 @@ func init() {
 		name: "unknown",
 		enter: func(net *Network, n *Node) {
 			net.tab.delete(n)
+			delete(net.nodes, n.ID)
 			n.pingEcho = nil
 			// Abort active queries.
 			for _, q := range n.deferredQueries {
@@ -997,6 +998,7 @@ func init() {
 				err := net.handleKnownPong(n, pkt)
 				return known, err
 			case pongTimeout:
+				delete(net.nodes, n.ID)
 				net.tab.deleteReplace(n)
 				return unresponsive, nil
 			case pingPacket:


### PR DESCRIPTION
Added eviction for the unresponsive nodes to prevent a DoS attack.
Tests have shown that attacking the discovery node with one thread, doesn't ever increase the memory usage past ~1.1gb, while the memory usage before that was growing indefinitely.

Related ticket: https://github.com/vechain/otherviews-workboard/issues/135
Fixes https://github.com/vechain/otherviews-workboard/issues/183